### PR TITLE
WIP: ghc 8.8.3 in 13-current

### DIFF
--- a/devel/hs-happy/Makefile
+++ b/devel/hs-happy/Makefile
@@ -2,7 +2,7 @@
 # $FreeBSD$
 
 PORTNAME=	happy
-PORTVERSION=	1.19.11
+PORTVERSION=	1.19.12
 CATEGORIES=	devel haskell
 
 MAINTAINER=	haskell@FreeBSD.org

--- a/devel/hs-happy/distinfo
+++ b/devel/hs-happy/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1563716379
-SHA256 (cabal/happy-1.19.11.tar.gz) = 9094d19ed0db980a34f1ffd58e64c7df9b4ecb3beed22fd9b9739044a8d45f77
-SIZE (cabal/happy-1.19.11.tar.gz) = 181528
+TIMESTAMP = 1585092550
+SHA256 (cabal/happy-1.19.12.tar.gz) = fb9a23e41401711a3b288f93cf0a66db9f97da1ce32ec4fffea4b78a0daeb40f
+SIZE (cabal/happy-1.19.12.tar.gz) = 183254


### PR DESCRIPTION
I'm doing what I can on the haskell ports, so far I got ghc 8.8.3 to build on 13-CURRENT thanks to arrowd's tip on IRC.

Also, by updating `devel/hs-happy` to 1.19.12 it builds again.